### PR TITLE
London | 25-SDC-July | Ali Qassab | Module Legacy Code | Sprint 1 | Can't log in from profile page #6

### DIFF
--- a/front-end/lib/api.mjs
+++ b/front-end/lib/api.mjs
@@ -1,5 +1,5 @@
-import {state} from "../index.mjs";
-import {handleErrorDialog} from "../components/error.mjs";
+import { state } from "../index.mjs";
+import { handleErrorDialog } from "../components/error.mjs";
 
 // === ABOUT THE STATE
 // state gives you these two functions only
@@ -20,13 +20,13 @@ async function _apiRequest(endpoint, options = {}) {
   const defaultOptions = {
     headers: {
       "Content-Type": "application/json",
-      ...(token ? {Authorization: `Bearer ${token}`} : {}),
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
     },
     mode: "cors",
     credentials: "include",
   };
 
-  const fetchOptions = {...defaultOptions, ...options};
+  const fetchOptions = { ...defaultOptions, ...options };
   const url = endpoint.startsWith("http") ? endpoint : `${baseUrl}${endpoint}`;
 
   try {
@@ -54,7 +54,7 @@ async function _apiRequest(endpoint, options = {}) {
     const contentType = response.headers.get("content-type");
     return contentType?.includes("application/json")
       ? await response.json()
-      : {success: true};
+      : { success: true };
   } catch (error) {
     if (!error.status) {
       // Only handle network errors here, response errors are handled above
@@ -70,11 +70,11 @@ function _updateProfile(username, profileData) {
   const index = profiles.findIndex((p) => p.username === username);
 
   if (index !== -1) {
-    profiles[index] = {...profiles[index], ...profileData};
+    profiles[index] = { ...profiles[index], ...profileData };
   } else {
-    profiles.push({username, ...profileData});
+    profiles.push({ username, ...profileData });
   }
-  state.updateState({profiles});
+  state.updateState({ profiles });
 }
 
 // ====== AUTH methods
@@ -82,7 +82,7 @@ async function login(username, password) {
   try {
     const data = await _apiRequest("/login", {
       method: "POST",
-      body: JSON.stringify({username, password}),
+      body: JSON.stringify({ username, password }),
     });
 
     if (data.success && data.token) {
@@ -96,7 +96,7 @@ async function login(username, password) {
 
     return data;
   } catch (error) {
-    return {success: false};
+    return { success: false };
   }
 }
 
@@ -104,12 +104,12 @@ async function getWhoToFollow() {
   try {
     const usernamesToFollow = await _apiRequest("/suggested-follows/3");
 
-    state.updateState({whoToFollow: usernamesToFollow});
+    state.updateState({ whoToFollow: usernamesToFollow });
 
     return usernamesToFollow;
   } catch (error) {
     // Error already handled by _apiRequest
-    state.updateState({usernamesToFollow: []});
+    state.updateState({ usernamesToFollow: [] });
     return [];
   }
 }
@@ -118,7 +118,7 @@ async function signup(username, password) {
   try {
     const data = await _apiRequest("/register", {
       method: "POST",
-      body: JSON.stringify({username, password}),
+      body: JSON.stringify({ username, password }),
     });
 
     if (data.success && data.token) {
@@ -132,20 +132,21 @@ async function signup(username, password) {
 
     return data;
   } catch (error) {
-    return {success: false};
+    return { success: false };
   }
 }
 
 function logout() {
   state.destroyState();
-  return {success: true};
+  window.location.hash = "/";
+  return { success: true };
 }
 
 // ===== BLOOM methods
 async function getBloom(bloomId) {
   const endpoint = `/bloom/${bloomId}`;
   const bloom = await _apiRequest(endpoint);
-  state.updateState({singleBloomToShow: bloom});
+  state.updateState({ singleBloomToShow: bloom });
   return bloom;
 }
 
@@ -156,18 +157,18 @@ async function getBlooms(username) {
     const blooms = await _apiRequest(endpoint);
 
     if (username) {
-      _updateProfile(username, {blooms});
+      _updateProfile(username, { blooms });
     } else {
-      state.updateState({timelineBlooms: blooms});
+      state.updateState({ timelineBlooms: blooms });
     }
 
     return blooms;
   } catch (error) {
     // Error already handled by _apiRequest
     if (username) {
-      _updateProfile(username, {blooms: []});
+      _updateProfile(username, { blooms: [] });
     } else {
-      state.updateState({timelineBlooms: []});
+      state.updateState({ timelineBlooms: [] });
     }
     return [];
   }
@@ -189,7 +190,7 @@ async function getBloomsByHashtag(hashtag) {
     return blooms;
   } catch (error) {
     // Error already handled by _apiRequest
-    return {success: false};
+    return { success: false };
   }
 }
 
@@ -197,7 +198,7 @@ async function postBloom(content) {
   try {
     const data = await _apiRequest("/bloom", {
       method: "POST",
-      body: JSON.stringify({content}),
+      body: JSON.stringify({ content }),
     });
 
     if (data.success) {
@@ -208,7 +209,7 @@ async function postBloom(content) {
     return data;
   } catch (error) {
     // Error already handled by _apiRequest
-    return {success: false};
+    return { success: false };
   }
 }
 
@@ -225,16 +226,16 @@ async function getProfile(username) {
       const currentUsername = profileData.username;
       const fullProfileData = await _apiRequest(`/profile/${currentUsername}`);
       _updateProfile(currentUsername, fullProfileData);
-      state.updateState({currentUser: currentUsername, isLoggedIn: true});
+      state.updateState({ currentUser: currentUsername, isLoggedIn: true });
     }
 
     return profileData;
   } catch (error) {
     // Error already handled by _apiRequest
     if (!username) {
-      state.updateState({isLoggedIn: false, currentUser: null});
+      state.updateState({ isLoggedIn: false, currentUser: null });
     }
-    return {success: false};
+    return { success: false };
   }
 }
 
@@ -242,7 +243,7 @@ async function followUser(username) {
   try {
     const data = await _apiRequest("/follow", {
       method: "POST",
-      body: JSON.stringify({follow_username: username}),
+      body: JSON.stringify({ follow_username: username }),
     });
 
     if (data.success) {
@@ -255,7 +256,7 @@ async function followUser(username) {
 
     return data;
   } catch (error) {
-    return {success: false};
+    return { success: false };
   }
 }
 
@@ -277,7 +278,7 @@ async function unfollowUser(username) {
     return data;
   } catch (error) {
     // Error already handled by _apiRequest
-    return {success: false};
+    return { success: false };
   }
 }
 
@@ -300,4 +301,4 @@ const apiService = {
   getWhoToFollow,
 };
 
-export {apiService};
+export { apiService };

--- a/front-end/views/hashtag.mjs
+++ b/front-end/views/hashtag.mjs
@@ -35,21 +35,24 @@ function hashtagView(hashtag) {
     createLogin
   );
   document
-    .querySelector("[data-action='login']")
-    ?.addEventListener("click", handleLogin);
+    .querySelector("[data-form='login']")
+    ?.addEventListener("submit", handleLogin);
 
-  renderOne(
-    state.currentHashtag,
-    getHeadingContainer(),
-    "heading-template",
-    createHeading
-  );
-  renderEach(
-    state.hashtagBlooms || [],
-    getTimelineContainer(),
-    "bloom-template",
-    createBloom
-  );
+  // Only show hashtag content if logged in
+  if (state.isLoggedIn) {
+    renderOne(
+      state.currentHashtag,
+      getHeadingContainer(),
+      "heading-template",
+      createHeading
+    );
+    renderEach(
+      state.hashtagBlooms || [],
+      getTimelineContainer(),
+      "bloom-template",
+      createBloom
+    );
+  }
 }
 
 export {hashtagView};

--- a/front-end/views/profile.mjs
+++ b/front-end/views/profile.mjs
@@ -9,7 +9,7 @@ import {
 } from "../index.mjs";
 import {createLogin, handleLogin} from "../components/login.mjs";
 import {createLogout, handleLogout} from "../components/logout.mjs";
-import {createProfile, handleFollow} from "../components/profile.mjs";
+import {createProfile} from "../components/profile.mjs";
 import {createBloom} from "../components/bloom.mjs";
 
 // Profile view - just this person's blooms and their profile
@@ -19,7 +19,7 @@ function profileView(username) {
   const existingProfile = state.profiles.find((p) => p.username === username);
 
   // Only fetch profile if we don't have it or if it's incomplete
-  if (!existingProfile || !existingProfile.recent_blooms) {
+  if (!existingProfile?.recent_blooms) {
     apiService.getProfile(username);
   }
 
@@ -39,27 +39,30 @@ function profileView(username) {
     createLogin
   );
   document
-    .querySelector("[data-action='login']")
-    ?.addEventListener("click", handleLogin);
+    .querySelector("[data-form='login']")
+    ?.addEventListener("submit", handleLogin);
 
-  const profileData = state.profiles.find((p) => p.username === username);
-  if (profileData) {
-    renderOne(
-      {
-        profileData,
-        whoToFollow: state.isLoggedIn ? state.whoToFollow : [],
-        isLoggedIn: state.isLoggedIn,
-      },
-      getProfileContainer(),
-      "profile-template",
-      createProfile
-    );
-    renderEach(
-      profileData.recent_blooms || [],
-      getTimelineContainer(),
-      "bloom-template",
-      createBloom
-    );
+  // Only show profile content if logged in
+  if (state.isLoggedIn) {
+    const profileData = state.profiles.find((p) => p.username === username);
+    if (profileData) {
+      renderOne(
+        {
+          profileData,
+          whoToFollow: state.whoToFollow,
+          isLoggedIn: state.isLoggedIn,
+        },
+        getProfileContainer(),
+        "profile-template",
+        createProfile
+      );
+      renderEach(
+        profileData.recent_blooms || [],
+        getTimelineContainer(),
+        "bloom-template",
+        createBloom
+      );
+    }
   }
 }
 


### PR DESCRIPTION
- Redirect users to home page after logout instead of staying on profile page
- Resolves 501 error when logging in from profile page after logout
- Fixes #6

<!--

You must title your PR like this:

Region | Cohort | FirstName LastName | Sprint | Assignment Title

For example,

London | 25-ITP-May | Carol Owen | Sprint 1 | Alarm Clock

Fill in the template below - remove any sections that don't apply.

Complete the self checklist - replace each empty box in the checklist [ ] with a [x].

Add the label "Needs Review" and you will get review.

Respond to volunteer reviews until the volunteer marks it as "Complete".

-->

## Learners, PR Template

Self checklist

- [ ] I have titled my PR with Region | Cohort | FirstName LastName | Sprint | Assignment Title
- [ ] My changes meet the requirements of the task
- [ ] I have tested my changes
- [ ] My changes follow the [style guide](https://curriculum.codeyourfuture.io/guides/reviewing/style-guide/)

## Changelist

**Problem:**
Users experienced a 501 "Server does not support this operation" error when:
Logging in → clicking a username → logging out → logging back in
Expected to see the profile page but got an error instead

**Root Cause:**
After logout, users remained on the profile page (#/profile/AS). When logging back in, the application tried to restore this profile page state, which triggered operations that caused the 501 error.

**Solution:**
Added navigation redirect to the logout function:

function logout() {
  state.destroyState();
  window.location.hash = "/";  // Redirect to home page
  return { success: true };
}


