### PR TITLE
London | 25-SDC-July | Ali Qassab | Module-Legacy-Code | Sprint 1 |  Hashtag link doesn't work correctly

### DIFF
--- a/front-end/components/bloom.mjs
+++ b/front-end/components/bloom.mjs
@@ -37,7 +37,8 @@ const createBloom = (template, bloom) => {
 function _formatHashtags(text) {
   if (!text) return text;
   return text.replace(
-    /\B#[^#]+/g,
+    /\B#\w+/g,
+    // /\B#[^#]+/g,
     (match) => `<a href="/hashtag/${match.slice(1)}">${match}</a>`
   );
 }
@@ -84,4 +85,4 @@ function _formatTimestamp(timestamp) {
   }
 }
 
-export {createBloom};
+export { createBloom };


### PR DESCRIPTION
<!--

You must title your PR like this:

Region | Cohort | FirstName LastName | Sprint | Assignment Title

For example,

London | 25-ITP-May | Carol Owen | Sprint 1 | Alarm Clock

Fill in the template below - remove any sections that don't apply.

Complete the self checklist - replace each empty box in the checklist [ ] with a [x].

Add the label "Needs Review" and you will get review.

Respond to volunteer reviews until the volunteer marks it as "Complete".

-->

## Learners, PR Template

Self checklist

- [ ] I have titled my PR with Region | Cohort | FirstName LastName | Sprint | Assignment Title
- [ ] My changes meet the requirements of the task
- [ ] I have tested my changes
- [ ] My changes follow the [style guide](https://curriculum.codeyourfuture.io/guides/reviewing/style-guide/)

## Fix Hashtag Parsing Issue

**Problem:** Hashtag links with spaces or punctuation were creating broken URLs and showing empty pages.

**Example:** Clicking `#SwizBiz` in "Let's get some #SwizBiz love!!" created URL `/hashtag/SwizBiz love!!` which showed no blooms.

**Solution:** Updated hashtag regex from `/\B#[^#]+/g` to `/\B#\w+/g` to only capture valid hashtag characters (letters, numbers, underscores).

**Result:** All `#SwizBiz` hashtags now correctly navigate to `/hashtag/SwizBiz` and show all related blooms.

**Files Changed:**
- `front-end/components/bloom.mjs` - Updated `_formatHashtags()` function

