### PR TITLE
London | 25-SDC-July | Fatma Arslantas | Sprint 1 | Hashtag link doesn't work correctly

### DIFF
--- a/front-end/components/bloom.mjs
+++ b/front-end/components/bloom.mjs
@@ -37,7 +37,7 @@ const createBloom = (template, bloom) => {
 function _formatHashtags(text) {
   if (!text) return text;
   return text.replace(
-    /\B#[^#]+/g,
+    /\B#\w+/g,
     (match) => `<a href="/hashtag/${match.slice(1)}">${match}</a>`
   );
 }


### PR DESCRIPTION
<!--

You must title your PR like this:

Region | Cohort | FirstName LastName | Sprint | Assignment Title

For example,

London | 25-ITP-May | Carol Owen | Sprint 1 | Alarm Clock

Fill in the template below - remove any sections that don't apply.

Complete the self checklist - replace each empty box in the checklist [ ] with a [x].

Add the label "Needs Review" and you will get review.

Respond to volunteer reviews until the volunteer marks it as "Complete".

-->

## Learners, PR Template

Self checklist

- [x] I have titled my PR with Region | Cohort | FirstName LastName | Sprint | Assignment Title
- [x] My changes meet the requirements of the task
- [x] I have tested my changes
- [x] My changes follow the [style guide](https://curriculum.codeyourfuture.io/guides/reviewing/style-guide/)

## Changelist

- The old code ([^#]+) was capturing too much text. It included spaces and punctuation (like !! or .) inside the hashtag link.
- I updated the regex in `bloom.mjs` from [^#]+ to \w+.
- Now, the hashtag link correctly stops at spaces and punctuation. #SwizBiz!! works perfectly now.

## Questions

I don’t have any questions, thank you!
