### PR TITLE
Sheffield | 25-SDC-Nov | Sheida Shabankari | Sprint 1 | Can't log in from profile page

### DIFF
--- a/front-end/tests/profile-logout-login.spec.mjs
+++ b/front-end/tests/profile-logout-login.spec.mjs
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { loginAsSample, logout } from "./test-utils.mjs";
+import { loginAsSample, logout, loginOnCurrentPage } from "./test-utils.mjs";
 
 test("can visit another user's profile after logout and re-login", async ({
   page,
@@ -14,8 +14,8 @@ test("can visit another user's profile after logout and re-login", async ({
   await logout(page);
 
   // When I log in again
-  await loginAsSample(page);
-
+  //await loginAsSample(page);
+  await loginOnCurrentPage(page);
   // And I visit the same profile again
   await page.goto("/#/profile/AS");
 

--- a/front-end/tests/profile-logout-login.spec.mjs
+++ b/front-end/tests/profile-logout-login.spec.mjs
@@ -1,0 +1,28 @@
+import { test, expect } from "@playwright/test";
+import { loginAsSample, logout } from "./test-utils.mjs";
+
+test("can visit another user's profile after logout and re-login", async ({
+  page,
+}) => {
+  // Given I am logged in
+  await loginAsSample(page);
+
+  // And I visit another user's profile
+  await page.goto("/#/profile/AS");
+
+  // And I log out
+  await logout(page);
+
+  // When I log in again
+  await loginAsSample(page);
+
+  // And I visit the same profile again
+  await page.goto("/#/profile/AS");
+
+  // Then I should see the profile view (NOT a server error)
+  await expect(page.locator("#profile-container")).toBeVisible();
+
+  await expect(page.locator("body")).not.toContainText(
+    "Server does not support this operation",
+  );
+});

--- a/front-end/tests/test-utils.mjs
+++ b/front-end/tests/test-utils.mjs
@@ -27,6 +27,16 @@ export async function loginAsJustSomeGuy(page) {
 }
 
 /**
+ * Log in on the current page without redirecting
+ * @param {import('@playwright/test').Page} page
+ */
+export async function loginOnCurrentPage(page) {
+  await page.fill('[data-form="login"] input[name="username"]', "sample");
+  await page.fill('[data-form="login"] input[name="password"]', "sosecret");
+  await page.locator('[data-form="login"]').evaluate(form => form.submit());
+}
+
+/**
  * Sign up with generated credentials
  * @param {import('@playwright/test').Page} page
  * @param {string} username - Username to sign up with

--- a/front-end/views/hashtag.mjs
+++ b/front-end/views/hashtag.mjs
@@ -35,8 +35,8 @@ function hashtagView(hashtag) {
     createLogin
   );
   document
-    .querySelector("[data-action='login']")
-    ?.addEventListener("click", handleLogin);
+    .querySelector("[data-form='login']")
+    ?.addEventListener("submit", handleLogin);
 
   renderOne(
     state.currentHashtag,

--- a/front-end/views/profile.mjs
+++ b/front-end/views/profile.mjs
@@ -39,8 +39,8 @@ function profileView(username) {
     createLogin
   );
   document
-    .querySelector("[data-action='login']")
-    ?.addEventListener("click", handleLogin);
+    .querySelector("[data-form='login']")
+    ?.addEventListener("submit", handleLogin);
 
   const profileData = state.profiles.find((p) => p.username === username);
   if (profileData) {


### PR DESCRIPTION
- [x] I have titled my PR with Region | Cohort | FirstName LastName | Sprint | Assignment Title
- [x] My changes meet the requirements of the task
- [x] I have tested my changes
- [x] My changes follow the [style guide](https://curriculum.codeyourfuture.io/guides/reviewing/style-guide/)

PR Summary:
Previously, visiting another user's profile after logging out and logging back in caused a server error (501: Server does not support this operation). The root cause was that the login button was handled via a click event, which did not properly trigger form submission and associated server logic in some cases.

The first login succeeded because the DOM and state were in a clean initial state. After logout, the login view was re-rendered, and the click-based handler was no longer reliably attached.

This PR changes the login flow to handle the form submit event instead of just the button click, ensuring that logging in fully executes the server-side login process. Handling login via the form’s submit event ensures consistent behaviour across re-renders. After this fix, users can log out and log back in, and visiting another user's profile works as expected.