### PR TITLE
WestMidlands | SDC Nov 2025| Sara Tahir | Sprint  1| ExtraLong Bloom

### DIFF
--- a/backend/endpoints.py
+++ b/backend/endpoints.py
@@ -153,19 +153,32 @@ def do_follow():
 @jwt_required()
 def send_bloom():
     type_check_error = verify_request_fields({"content": str})
+
     if type_check_error is not None:
         return type_check_error
+    
+    
+    content = request.json["content"]
+
+    MAXIMUM_BLOOM_LENGTH = 280
+
+    
+    if len(content) > MAXIMUM_BLOOM_LENGTH:
+        return make_response(
+            (
+                {
+                    "success": False,
+                    "message": f"Bloom cannot exceed {MAXIMUM_BLOOM_LENGTH} characters.",
+                },
+                400,
+            )
+        )
 
     user = get_current_user()
 
-    blooms.add_bloom(sender=user, content=request.json["content"])
+    blooms.add_bloom(sender=user, content=content)
 
-    return jsonify(
-        {
-            "success": True,
-        }
-    )
-
+    return jsonify({"success": True})
 
 def get_bloom(id_str):
     try:


### PR DESCRIPTION
<!--

You must title your PR like this:

Region | Cohort | FirstName LastName | Sprint | Assignment Title

For example,

London | 25-ITP-May | Carol Owen | Sprint 1 | Alarm Clock

Fill in the template below - remove any sections that don't apply.

Complete the self checklist - replace each empty box in the checklist [ ] with a [x].

Add the label "Needs Review" and you will get review.

Respond to volunteer reviews until the volunteer marks it as "Complete".

-->

## Learners, PR Template

Self checklist

- [x] I have titled my PR with Region | Cohort | FirstName LastName | Sprint | Assignment Title
- [x] My changes meet the requirements of the task
- [x] I have tested my changes
- [x] My changes follow the [style guide](https://curriculum.codeyourfuture.io/guides/reviewing/style-guide/)

## Changelist

1. Added server‑side length check to ensure bloom content does not exceed 280 characters.
2. Returns a 400 error with a clear message when the limit is exceeded.
3. Aligns backend behaviour with existing frontend maxlength restriction.
4. Manually verified by removing the maxlength attribute in DevTools and confirming the backend now rejects oversized blooms.

## Questions
I initially planned to use the more robust request.get_json().get("content") pattern, but since this backend consistently accesses JSON via request.json["..."], I kept the implementation aligned with the current style. I want to know whats the best approach while working with legacy code, do we always keep our implementationa aligned with the current style ?