### PR TITLE
Glasgow | 25-SDC-Nov | Nataliia Volkova | Sprint 1 | Bug Report: Extra long blooms

### DIFF
--- a/backend/endpoints.py
+++ b/backend/endpoints.py
@@ -149,6 +149,7 @@ def do_follow():
         }
     )
 
+max_length = 280
 
 @jwt_required()
 def send_bloom():
@@ -158,7 +159,7 @@ def send_bloom():
     
     content = request.json["content"]
 
-    if len(content) > 280:
+    if len(content) > max_length:
         return {
             "success": False,
             "error": "Bloom content can't be more than 280 characters"

--- a/backend/endpoints.py
+++ b/backend/endpoints.py
@@ -155,10 +155,18 @@ def send_bloom():
     type_check_error = verify_request_fields({"content": str})
     if type_check_error is not None:
         return type_check_error
+    
+    content = request.json["content"]
 
+    if len(content) > 280:
+        return {
+            "success": False,
+            "error": "Bloom content can't be more than 280 characters"
+        }, 400
+    
     user = get_current_user()
 
-    blooms.add_bloom(sender=user, content=request.json["content"])
+    blooms.add_bloom(sender=user, content=content)
 
     return jsonify(
         {

--- a/backend/populate.py
+++ b/backend/populate.py
@@ -38,6 +38,25 @@ def send_bloom(access_token: str, text: str) -> None:
     post("/bloom", data={"content": text}, access_token=access_token)
 
 
+MAX_BLOOM_LENGTH = 280
+
+def send_long_bloom(access_token: str, text: str) -> None:
+    text = " ".join(text.split())
+
+    while text:
+        chunk = text[:MAX_BLOOM_LENGTH]
+
+        if len(text) > MAX_BLOOM_LENGTH:
+            cut = chunk.rfind(" ")
+            if cut > 0:
+                chunk = chunk[:cut]
+
+        send_bloom(access_token, chunk)
+        # print(len(chunk), repr(chunk))
+
+        text = text[len(chunk):].strip()
+
+
 def follow(*, follower_access_token: str, follow_username: str) -> None:
     post(
         "/follow",

--- a/backend/populate.py
+++ b/backend/populate.py
@@ -38,24 +38,6 @@ def send_bloom(access_token: str, text: str) -> None:
     post("/bloom", data={"content": text}, access_token=access_token)
 
 
-MAX_BLOOM_LENGTH = 280
-
-def send_long_bloom(access_token: str, text: str) -> None:
-    text = " ".join(text.split())
-
-    while text:
-        chunk = text[:MAX_BLOOM_LENGTH]
-
-        if len(text) > MAX_BLOOM_LENGTH:
-            cut = chunk.rfind(" ")
-            if cut > 0:
-                chunk = chunk[:cut]
-
-        send_bloom(access_token, chunk)
-        # print(len(chunk), repr(chunk))
-
-        text = text[len(chunk):].strip()
-
 
 def follow(*, follower_access_token: str, follow_username: str) -> None:
     post(


### PR DESCRIPTION
<!--

You must title your PR like this:

Region | Cohort | FirstName LastName | Sprint | Assignment Title

For example,

London | 25-ITP-May | Carol Owen | Sprint 1 | Alarm Clock

Fill in the template below - remove any sections that don't apply.

Complete the self checklist - replace each empty box in the checklist [ ] with a [x].

Add the label "Needs Review" and you will get review.

Respond to volunteer reviews until the volunteer marks it as "Complete".

Please note: if the PR template is not filled as described above, an automatic GitHub bot will give feedback in the "Conversation" tab of the pull request and not allow the "Needs Review" label to be added until it's fixed.

-->

## Learners, PR Template

Self checklist

- [x] I have titled my PR with Region | Cohort | FirstName LastName | Sprint | Assignment Title
- [x] My changes meet the requirements of the task
- [x] I have tested my changes
- [x] My changes follow the [style guide](https://curriculum.codeyourfuture.io/guides/reviewing/style-guide/)

## Changelist

Validated length blooms on backend on endponts.py as it is a single source of truth. Added to populate.py logic to automate splitting next long blooms on separate blooms.(second sentence related to seeds, not to users' blooms).