### PR TITLE
London | November 25 | Donara Blanc | Sprint 1 | Fix hashtag links

### DIFF
--- a/front-end/components/bloom.mjs
+++ b/front-end/components/bloom.mjs
@@ -37,7 +37,7 @@ const createBloom = (template, bloom) => {
 function _formatHashtags(text) {
   if (!text) return text;
   return text.replace(
-    /\B#[^#]+/g,
+    /\b#\w+/g,
     (match) => `<a href="/hashtag/${match.slice(1)}">${match}</a>`
   );
 }


### PR DESCRIPTION

Self checklist

- [x] I have titled my PR with Region | Cohort | FirstName LastName | Sprint | Assignment Title
- [x ] My changes meet the requirements of the task
- [x] I have tested my changes
- [x] My changes follow the [style guide](https://curriculum.codeyourfuture.io/guides/reviewing/style-guide/)

## Changelist

fixed regex in `_formatHashtags()` in `front-end/components/bloom.mjs`
changed `\B` to `\b` so hashtags after spaces are correctly matched
changed `[^#]+` to `\w+` for more precise pattern
it fixes the bug where clicking #SwizBiz in some blooms led to an empty page
