### PR TITLE
London | 25-SDC-Nov | Jesus del Moral | Sprint 1 | hashtag slowing down the browser

### DIFF
--- a/front-end/index.mjs
+++ b/front-end/index.mjs
@@ -37,12 +37,7 @@ async function init() {
       await apiService.getProfile(profileUsername);
     }
   }
-
   handleRouteChange();
-
-  document.addEventListener("state-change", () => {
-    handleRouteChange();
-  });
 }
 
 // TODO Check any unhandled errors bubble up to this central handler

--- a/front-end/views/hashtag.mjs
+++ b/front-end/views/hashtag.mjs
@@ -14,10 +14,13 @@ import {createHeading} from "../components/heading.mjs";
 
 // Hashtag view: show all tweets containing this tag
 
-function hashtagView(hashtag) {
+async function hashtagView(hashtag) {
   destroy();
 
-  apiService.getBloomsByHashtag(hashtag);
+  // prevent infinite loop
+  if (state.currentHashtag !== `#${hashtag}`) {
+    await apiService.getBloomsByHashtag(hashtag);
+  }
 
   renderOne(
     state.isLoggedIn,
@@ -28,6 +31,7 @@ function hashtagView(hashtag) {
   document
     .querySelector("[data-action='logout']")
     ?.addEventListener("click", handleLogout);
+
   renderOne(
     state.isLoggedIn,
     getLoginContainer(),
@@ -35,8 +39,8 @@ function hashtagView(hashtag) {
     createLogin
   );
   document
-    .querySelector("[data-action='login']")
-    ?.addEventListener("click", handleLogin);
+    .querySelector('[data-form="login"]')
+    ?.addEventListener("submit", handleLogin); // also fix this 👀
 
   renderOne(
     state.currentHashtag,
@@ -44,6 +48,7 @@ function hashtagView(hashtag) {
     "heading-template",
     createHeading
   );
+
   renderEach(
     state.hashtagBlooms || [],
     getTimelineContainer(),


### PR DESCRIPTION
This PR fixes an issue where clicking on hashtags caused the page to repeatedly re-render, resulting in a flashing blank screen and degraded browser performance. The fix ensures that hashtag navigation no longer triggers unnecessary re-renders or repeated data fetching