### PR TITLE
Birmingham | 2026-MAR-SDC | Joy Opachavalit | Sprint 1 | Can't log in from profile page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,26 @@
 .DS_Store
+
+# Python
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.coverage
+.venv/
+backend/venv/
+
+# Environment files
+.env
+backend/.env
+
+# Node / frontend
+node_modules/
+front-end/node_modules/
+playwright-report/
+test-results/
+
+# Database data
+db/pg_data/
+
+# Editor / OS files
+.idea/
+.vscode/

--- a/front-end/views/hashtag.mjs
+++ b/front-end/views/hashtag.mjs
@@ -35,8 +35,8 @@ function hashtagView(hashtag) {
     createLogin
   );
   document
-    .querySelector("[data-action='login']")
-    ?.addEventListener("click", handleLogin);
+    .querySelector("[data-form='login']")
+    ?.addEventListener("submit", handleLogin);
 
   renderOne(
     state.currentHashtag,

--- a/front-end/views/profile.mjs
+++ b/front-end/views/profile.mjs
@@ -39,8 +39,8 @@ function profileView(username) {
     createLogin
   );
   document
-    .querySelector("[data-action='login']")
-    ?.addEventListener("click", handleLogin);
+    .querySelector("[data-form='login']")
+    ?.addEventListener("submit", handleLogin);
 
   const profileData = state.profiles.find((p) => p.username === username);
   if (profileData) {


### PR DESCRIPTION
# Learners, PR Template

Self checklist

- [x] I have titled my PR with Region | Cohort | FirstName LastName | Sprint | Assignment Title
- [x] My changes meet the requirements of the task
- [x] I have tested my changes
- [x] My changes follow the [style guide](https://curriculum.codeyourfuture.io/guides/reviewing/style-guide/)


## Changelist

Fix: Correct login form handler binding in profile and hashtag views

## Problem
Users encountered a 501 error when logging in from the profile or hashtag 
pages after logging out. The issue occurred because the login form handler 
was incorrectly bound to a link click event instead of the form submit event.

## Root Cause
- profile.mjs and hashtag.mjs used "[data-action='login']" selector (wrong element)
- Event listener was set to "click" instead of "submit"
- This meant the form submission wasn't intercepted by the Single‑Page Application handler
- The browser attempted a default POST to the current page URL
- Backend has no handler for POST /profile/<username> or POST /hashtag/<tag>
- Result: 501 error

## Solution
- Updated both files to use "[data-form='login']" selector (correct element)
- Changed event from "click" to "submit"
- Now matches the working implementation in bloom.mjs and home.mjs
- Form submission is now properly intercepted and handled client-side

## Files Changed
- front-end/views/profile.mjs
- front-end/views/hashtag.mjs

## Testing
Users can now:
1. Log in as sample/sosecret
2. Click on a username to view their profile
3. Click logout
4. Log in again as sample/sosecret
5. See the logged-in profile view (no 501 error)