### PR TITLE
London | 26-SDC-Mar | Craig D'Silva | Sprint 1 | Hashtag link fix

### DIFF
--- a/front-end/components/bloom.mjs
+++ b/front-end/components/bloom.mjs
@@ -34,10 +34,10 @@ const createBloom = (template, bloom) => {
   return bloomFrag;
 };
 
-function _formatHashtags(text) {
+export function _formatHashtags(text) {
   if (!text) return text;
   return text.replace(
-    /\B#[^#]+/g,
+    /\B#[^#\s]+/g,
     (match) => `<a href="/hashtag/${match.slice(1)}">${match}</a>`
   );
 }

--- a/front-end/tests/bloom.spec.mjs
+++ b/front-end/tests/bloom.spec.mjs
@@ -1,0 +1,26 @@
+import { test, expect } from "@playwright/test";
+import { _formatHashtags } from "../components/bloom.mjs";
+
+test.describe("Bloom Component", () => {
+  test("should format a single hashtag in a bloom", () => {
+    const text = "Test #do";
+    const result = _formatHashtags(text);
+    expect(result).toContain('<a href="/hashtag/do">#do</a>');
+  });
+
+  test("should format multiple hashtags in a bloom", () => {
+    const text = "Tech is magic #blessed #TechLife";
+    const result = _formatHashtags(text);
+    expect(result).toContain('<a href="/hashtag/blessed">#blessed</a>');
+    expect(result).toContain('<a href="/hashtag/TechLife">#TechLife</a>');
+  });
+
+  test("should not include word after hashtag that is not a hashtag", () => {
+    const text = "Let's get some #SwizBiz love!!";
+    const result = _formatHashtags(text);
+    expect(result).toContain('<a href="/hashtag/SwizBiz">#SwizBiz</a>');
+    expect(result).not.toContain(
+      '<a href="/hashtag/SwizBiz">#SwizBiz love!!</a>',
+    );
+  });
+});


### PR DESCRIPTION
<!--

You must title your PR like this:

Region | Cohort | FirstName LastName | Sprint | Assignment Title

For example,

London | 25-ITP-May | Carol Owen | Sprint 1 | Alarm Clock

Fill in the template below - remove any sections that don't apply.

Complete the self checklist - replace each empty box in the checklist [ ] with a [x].

Add the label "Needs Review" and you will get review.

Respond to volunteer reviews until the volunteer marks it as "Complete".

Please note: if the PR template is not filled as described above, an automatic GitHub bot will give feedback in the "Conversation" tab of the pull request and not allow the "Needs Review" label to be added until it's fixed.

-->

## Learners, PR Template

Self checklist

- [x] I have titled my PR with Region | Cohort | FirstName LastName | Sprint | Assignment Title
- [x] My changes meet the requirements of the task
- [x] I have tested my changes

## Changelist

This fixes the hashtag links shown on the bloom.

## How to test

1. Log in to Purple Forest.
2. Scroll down to the "Let's get some #SwizBiz love!!" bloom.
3. Make sure the word "love" is not part of the link "#SwizBiz".
4. Click on the hashtag link, and you should see all the blooms with that hashtag.