### PR TITLE
NW | 26-SDC-Mar | TzeMing Ho | Sprint 1 | extra-long-blooms

### DIFF
--- a/backend/endpoints.py
+++ b/backend/endpoints.py
@@ -155,6 +155,17 @@ def send_bloom():
     type_check_error = verify_request_fields({"content": str})
     if type_check_error is not None:
         return type_check_error
+    
+    bloom_content = request.json["content"]
+
+    if len(bloom_content) > 280:
+        return make_response(
+            jsonify({
+                "success": False,
+                "message": "Bloom content cannot exceed 280 characters"
+            }),
+            400
+        )
 
     user = get_current_user()
 

--- a/backend/endpoints.py
+++ b/backend/endpoints.py
@@ -158,11 +158,13 @@ def send_bloom():
     
     bloom_content = request.json["content"]
 
-    if len(bloom_content) > 280:
+    character_limit = 280
+
+    if len(bloom_content) > character_limit:
         return make_response(
             jsonify({
                 "success": False,
-                "message": "Bloom content cannot exceed 280 characters"
+                "message": f"Bloom content cannot exceed {character_limit} characters"
             }),
             400
         )


### PR DESCRIPTION
<!--

You must title your PR like this:

Region | Cohort | FirstName LastName | Sprint | Assignment Title

For example,

London | 25-ITP-May | Carol Owen | Sprint 1 | Alarm Clock

Fill in the template below - remove any sections that don't apply.

Complete the self checklist - replace each empty box in the checklist [ ] with a [x].

Add the label "Needs Review" and you will get review.

Respond to volunteer reviews until the volunteer marks it as "Complete".

Please note: if the PR template is not filled as described above, an automatic GitHub bot will give feedback in the "Conversation" tab of the pull request and not allow the "Needs Review" label to be added until it's fixed.

-->

## Learners, PR Template

Self checklist

- [x] I have titled my PR with Region | Cohort | FirstName LastName | Sprint | Assignment Title
- [x] My changes meet the requirements of the task
- [x] I have tested my changes
- [x] My changes follow the [style guide](https://curriculum.codeyourfuture.io/guides/reviewing/style-guide/)

## Changelist

I have tried to replicate the extra-long blooms from the frontend. However, it won't accept my input. So, I believe the problem is with the backend that allows content to be parsed by the terminal. 
A length check is added to send_bloom in the endpoints.py
