### PR TITLE
West Midlands | 26 March SDC | Iswat Bello | Sprint 1 | Purple Forest/bug report/Extra long blooms

### DIFF
--- a/backend/endpoints.py
+++ b/backend/endpoints.py
@@ -164,7 +164,7 @@ def send_bloom():
             (
                 {
                     "success": False,
-                    "message": f"Bloom must be less than {MAX_BLOOM_LENGTH} characters long",
+                    "message": f"Bloom must not exceed {MAX_BLOOM_LENGTH} characters",
                 },
                 400
             )

--- a/backend/endpoints.py
+++ b/backend/endpoints.py
@@ -18,6 +18,7 @@ from flask_jwt_extended import (
 from datetime import timedelta
 
 MINIMUM_PASSWORD_LENGTH = 5
+MAX_BLOOM_LENGTH = 280
 
 
 def login():
@@ -158,6 +159,16 @@ def send_bloom():
 
     user = get_current_user()
 
+    if len(request.json["content"]) > MAX_BLOOM_LENGTH:
+        return make_response(
+            (
+                {
+                    "success": False,
+                    "message": f"Bloom must be less than {MAX_BLOOM_LENGTH} characters long",
+                },
+                400
+            )
+        )
     blooms.add_bloom(sender=user, content=request.json["content"])
 
     return jsonify(


### PR DESCRIPTION
<!--

You must title your PR like this:

Region | Cohort | FirstName LastName | Sprint | Assignment Title

For example,

London | 25-ITP-May | Carol Owen | Sprint 1 | Alarm Clock

Fill in the template below - remove any sections that don't apply.

Complete the self checklist - replace each empty box in the checklist [ ] with a [x].

Add the label "Needs Review" and you will get review.

Respond to volunteer reviews until the volunteer marks it as "Complete".

Please note: if the PR template is not filled as described above, an automatic GitHub bot will give feedback in the "Conversation" tab of the pull request and not allow the "Needs Review" label to be added until it's fixed.

-->

## Learners, PR Template

Self checklist

- [x] I have titled my PR with Region | Cohort | FirstName LastName | Sprint | Assignment Title
- [x] My changes meet the requirements of the task
- [x] I have tested my changes
- [x] My changes follow the [style guide](https://curriculum.codeyourfuture.io/guides/reviewing/style-guide/)

## Changelist
This PR fixes a bug whereby the application allowed blooms (posts) longer than 280 characters to be saved to the database. While the frontend had validation, the backend lacked a "security guard" to prevent direct API requests or scripts from bypassing the limit.

**The Problem:** The application was only validating bloom length on the frontend. This allowed scripts (like `populate.py`) or direct API requests to save blooms longer than 280 characters, breaking the business rules.

**The Fix:**
*   Added a `MAX_BLOOM_LENGTH` constant (280) to the backend.
*   Updated the `send_bloom` function in `endpoints.py` to check the length of the incoming content.
*   The backend now returns a `400 Bad Request` if the bloom exceeds the limit.

**Verification:**
*   I performed a factory reset of the database and ran `populate.py`.
*   Confirmed that the backend successfully rejected the oversized bloom from the script with a 400 error.
*   Verified via DBeaver that the invalid bloom was not saved to the database.
