### PR TITLE
West Midlands | 26 March SDC | Iswat Bello | Sprint 1 | Purple Forest/bug report/Hashtag link doesn't work

### DIFF
--- a/front-end/components/bloom.mjs
+++ b/front-end/components/bloom.mjs
@@ -37,7 +37,7 @@ const createBloom = (template, bloom) => {
 function _formatHashtags(text) {
   if (!text) return text;
   return text.replace(
-    /\B#[^#]+/g,
+    /\B#[\w]+/g,
     (match) => `<a href="/hashtag/${match.slice(1)}">${match}</a>`
   );
 }


### PR DESCRIPTION
<!--

You must title your PR like this:

Region | Cohort | FirstName LastName | Sprint | Assignment Title

For example,

London | 25-ITP-May | Carol Owen | Sprint 1 | Alarm Clock

Fill in the template below - remove any sections that don't apply.

Complete the self checklist - replace each empty box in the checklist [ ] with a [x].

Add the label "Needs Review" and you will get review.

Respond to volunteer reviews until the volunteer marks it as "Complete".

Please note: if the PR template is not filled as described above, an automatic GitHub bot will give feedback in the "Conversation" tab of the pull request and not allow the "Needs Review" label to be added until it's fixed.

-->

## Learners, PR Template

Self checklist

- [x] I have titled my PR with Region | Cohort | FirstName LastName | Sprint | Assignment Title
- [x] My changes meet the requirements of the task
- [x] I have tested my changes
- [x] My changes follow the [style guide](https://curriculum.codeyourfuture.io/guides/reviewing/style-guide/)

## Changelist

This PR fixes a bug where hashtags located in the middle of a sentence were incorrectly linked because the application captured trailing spaces and punctuation as part of the hashtag name.

### **1. Reproduction Steps**
To confirm the bug, I performed the following:
1.  Loaded the database with sample data.
2.  From the UI, I located the bloom from user `Swiz`: *"Let's get some #SwizBiz love!!"*
3.  Clicked on the **#SwizBiz** link.
4.  **Observation:** The page loaded but was completely empty.
5.  **Network Trace:** I checked the Chrome DevTools Network tab and found that the request URL was: `http://localhost:3000/hashtag/SwizBiz%2520love!!`. 
6.  **Diagnosis:** The application was trying to search for a hashtag that included the trailing space and the next word ("love!!").

### **2. The Problem**
Hashtags located in the middle of a sentence were being "over-captured." Because the link included spaces and punctuation, the backend could not find a match in the database, resulting in an empty results page.

### **3. The Discovery**
I investigated `frontend/components/bloom.mjs` and found the `_formatHashtags` function. 
*   **The Bug:** It used a Regex pattern: `/\B#[^#]+/g`.
*   **The Logic Error:** The `[^#]+` part tells the browser to "capture every character that is NOT a hash." Since spaces and exclamation marks are not hashes, the browser kept grabbing them until the end of the string.

### **4. The Fix**
I updated the Regex pattern in `frontend/components/bloom.mjs` to:
`/\B#\w+/g`

### **5. The Logic**
By switching to **`\w+`**, the Regex is now restricted to "Word Characters" (letters, numbers, and underscores). 
*   **Result:** As soon as the browser hits a space, a period, or an exclamation mark, it realizes that character is not a "word character" and stops the hashtag capture immediately.

### **6. Verification**
After the fix, I returned to the timeline and clicked the same link.
*   **Observation:** The search now correctly displays all blooms containing `#SwizBiz`.
*   **Network Trace:** Confirmed the request is now clean: `/hashtag/SwizBiz`.
