### PR TITLE
West Midlands | 26 March SDC | Iswat Bello | Sprint 1 | Purple Forest/bug report/Hashtag slowing down my browser

### DIFF
--- a/front-end/views/hashtag.mjs
+++ b/front-end/views/hashtag.mjs
@@ -15,9 +15,13 @@ import {createHeading} from "../components/heading.mjs";
 // Hashtag view: show all tweets containing this tag
 
 function hashtagView(hashtag) {
-  destroy();
 
-  apiService.getBloomsByHashtag(hashtag);
+  const formattedHashtag = `#${hashtag}`; 
+  if (state.currentHashtag !== formattedHashtag) {
+    destroy();
+    apiService.getBloomsByHashtag(hashtag);
+  }
+ 
 
   renderOne(
     state.isLoggedIn,


### PR DESCRIPTION
<!--

You must title your PR like this:

Region | Cohort | FirstName LastName | Sprint | Assignment Title

For example,

London | 25-ITP-May | Carol Owen | Sprint 1 | Alarm Clock

Fill in the template below - remove any sections that don't apply.

Complete the self checklist - replace each empty box in the checklist [ ] with a [x].

Add the label "Needs Review" and you will get review.

Respond to volunteer reviews until the volunteer marks it as "Complete".

Please note: if the PR template is not filled as described above, an automatic GitHub bot will give feedback in the "Conversation" tab of the pull request and not allow the "Needs Review" label to be added until it's fixed.

-->

## Learners, PR Template

Self checklist

- [x] I have titled my PR with Region | Cohort | FirstName LastName | Sprint | Assignment Title
- [x] My changes meet the requirements of the task
- [x] I have tested my changes
- [x] My changes follow the [style guide](https://curriculum.codeyourfuture.io/guides/reviewing/style-guide/)

## Changelist

This PR resolves the infinite flickering issue on hashtag pages by implementing a guard clause within the hashtagView function. This prevents a circular logic loop where state updates were triggering redundant route changes and repeated API requests.

**The Problem:** When visiting a hashtag page, the application became stuck in an infinite loop. The screen would flash blank repeatedly, and the Network tab showed continuous API requests to the same endpoint.

**The Discovery:** I traced the logic through `index.mjs`, `router.mjs`, and `hashtag.mjs`. 
*   **The Loop:** The `hashtagView` was calling the API every time it ran. The API updated the state, which triggered a `state-change` event. The `index.mjs` listener heard this event and told the router to run again, starting the cycle over.
*   **The Flicker:** The `destroy()` function was being called at the start of every loop iteration, wiping the screen before the data could be rendered.

**The Fix:**
*   Implemented a **Guard Clause** in `hashtagView.mjs`.
*   **The Logic:** The function now checks if the requested hashtag is already the `currentHashtag` in the state. 
*   It only clears the screen and calls the API if the user is navigating to a **new** hashtag.

**Verification:**
*   Confirmed that the flickering has stopped.
*   Verified in the Network tab that only one API request is made per hashtag navigation.
