### PR TITLE
Birmingham | 2026-MAR-SDC | Joy Opachavalit | Sprint 1 | Hashtag slowing down my browser

### DIFF
--- a/front-end/views/hashtag.mjs
+++ b/front-end/views/hashtag.mjs
@@ -17,7 +17,15 @@ import {createHeading} from "../components/heading.mjs";
 function hashtagView(hashtag) {
   destroy();
 
-  apiService.getBloomsByHashtag(hashtag);
+  // Normalise to the same shape the API stores in state (e.g. "do" -> "#do")
+  const normalisedTag = `#${hashtag.startsWith("#") ? hashtag.substring(1) : hashtag}`;
+
+  // Only fetch if this hashtag isn't already loaded. Without this guard,
+  // every render fetches -> updates state -> fires "state-change" -> re-renders,
+  // an infinite loop that flashes the page blank and hangs the browser.
+  if (state.currentHashtag !== normalisedTag) {
+    apiService.getBloomsByHashtag(hashtag);
+  }
 
   renderOne(
     state.isLoggedIn,


### PR DESCRIPTION
# Learners, PR Template

Self checklist

- [x] I have titled my PR with Region | Cohort | FirstName LastName | Sprint | Assignment Title
- [x] My changes meet the requirements of the task
- [x] I have tested my changes
- [x] My changes follow the [style guide](https://curriculum.codeyourfuture.io/guides/reviewing/style-guide/)


## Changelist
Wrapping the existing `apiService.getBloomsByHashtag(hashtag)` call in an `if` guard so it stops fetching once the hashtag's data is already in state, which breaks the infinite render loop.
