### PR TITLE
NW | 26-SDC-Mar | TzeMing Ho | Sprint 1 | feature rebloom

### DIFF
--- a/backend/data/blooms.py
+++ b/backend/data/blooms.py
@@ -90,6 +90,39 @@ def get_blooms_for_user(
             )
     return blooms
 
+def get_reblooms_for_user(username: str) -> List[Bloom]:
+    with db_cursor() as cur:
+        cur.execute(
+            """
+            SELECT 
+                blooms.id, users.username, blooms.content, blooms.send_timestamp 
+            FROM 
+                reblooms 
+                INNER JOIN blooms ON blooms.id = reblooms.bloom_id
+                INNER JOIN users ON users.id = blooms.sender_id
+                INNER JOIN users AS rebloomer ON rebloomer.id = reblooms.user_id
+            WHERE
+                rebloomer.username = %(username)s
+            ORDER BY reblooms.rebloom_timestamp DESC
+            """,
+            dict(username=username)
+        )
+        rows = cur.fetchall()
+
+        reblooms = []
+        for row in rows:
+            bloom_id, send_username, content, timestamp = row
+            reblooms.append(
+                Bloom(
+                    id=bloom_id,
+                    sender=send_username,
+                    content=content,
+                    sent_timestamp=timestamp,
+                )
+            )
+    return reblooms
+
+
 
 def get_bloom(bloom_id: int) -> Optional[Bloom]:
     with db_cursor() as cur:

--- a/backend/data/blooms.py
+++ b/backend/data/blooms.py
@@ -13,7 +13,6 @@ class Bloom:
     sender: User
     content: str
     sent_timestamp: datetime.datetime
-    rebloom_count: int = 0
 
 def add_bloom(*, sender: User, content: str) -> Bloom:
     hashtags = [word[1:] for word in content.split(" ") if word.startswith("#")]

--- a/backend/data/blooms.py
+++ b/backend/data/blooms.py
@@ -13,7 +13,7 @@ class Bloom:
     sender: User
     content: str
     sent_timestamp: datetime.datetime
-
+    rebloom_count: int = 0
 
 def add_bloom(*, sender: User, content: str) -> Bloom:
     hashtags = [word[1:] for word in content.split(" ") if word.startswith("#")]

--- a/backend/data/blooms.py
+++ b/backend/data/blooms.py
@@ -90,10 +90,21 @@ def get_blooms_for_user(
             )
     return blooms
 
-def get_reblooms_for_user(username: str) -> List[Bloom]:
+def get_reblooms_for_user(username: str, *, before: Optional[int] = None, limit: Optional[int] = None) -> List[Bloom]:
     with db_cursor() as cur:
+        kwargs = {
+            "username": username,
+        }
+        if before is not None:
+            before_clause = "AND send_timestamp < %(before_limit)s"
+            kwargs["before_limit"] = before
+        else:
+            before_clause = ""
+
+        limit_clause = make_limit_clause(limit, kwargs)
+
         cur.execute(
-            """
+            f"""
             SELECT 
                 blooms.id, users.username, blooms.content, blooms.send_timestamp 
             FROM 
@@ -103,9 +114,11 @@ def get_reblooms_for_user(username: str) -> List[Bloom]:
                 INNER JOIN users AS rebloomer ON rebloomer.id = reblooms.user_id
             WHERE
                 rebloomer.username = %(username)s
+                {before_clause}
             ORDER BY reblooms.rebloom_timestamp DESC
+            {limit_clause}
             """,
-            dict(username=username)
+            kwargs
         )
         rows = cur.fetchall()
 

--- a/backend/data/blooms.py
+++ b/backend/data/blooms.py
@@ -14,6 +14,7 @@ class Bloom:
     content: str
     sent_timestamp: datetime.datetime
     activity_timestamp: datetime.datetime
+    rebloom_count: int
 
 @dataclass
 class RebloomView:
@@ -23,6 +24,7 @@ class RebloomView:
     sent_timestamp: datetime.datetime
     rebloomer: str
     activity_timestamp: datetime.datetime
+    rebloom_count: int
 
 def add_bloom(*, sender: User, content: str) -> Bloom:
     hashtags = [word[1:] for word in content.split(" ") if word.startswith("#")]
@@ -74,7 +76,8 @@ def get_blooms_for_user(
 
         cur.execute(
             f"""SELECT
-              blooms.id, users.username, content, send_timestamp
+              blooms.id, users.username, content, send_timestamp,
+              (SELECT COUNT(*) FROM reblooms WHERE reblooms.bloom_id = blooms.id) AS rebloom_count
             FROM
               blooms INNER JOIN users ON users.id = blooms.sender_id
             WHERE
@@ -88,14 +91,15 @@ def get_blooms_for_user(
         rows = cur.fetchall()
         blooms = []
         for row in rows:
-            bloom_id, sender_username, content, timestamp = row
+            bloom_id, sender_username, content, timestamp, rebloom_count = row
             blooms.append(
                 Bloom(
                     id=bloom_id,
                     sender=sender_username,
                     content=content,
                     sent_timestamp=timestamp,
-                    activity_timestamp=timestamp
+                    activity_timestamp=timestamp,
+                    rebloom_count=rebloom_count
                 )
             )
     return blooms
@@ -116,7 +120,8 @@ def get_reblooms_for_user(username: str, *, before: Optional[int] = None, limit:
         cur.execute(
             f"""
             SELECT 
-                blooms.id, users.username AS sender, blooms.content, blooms.send_timestamp, rebloomer.username AS rebloomer, reblooms.rebloom_timestamp AS activity_time
+                blooms.id, users.username AS sender, blooms.content, blooms.send_timestamp, rebloomer.username AS rebloomer, reblooms.rebloom_timestamp AS activity_time,
+                (SELECT COUNT(*) FROM reblooms WHERE reblooms.bloom_id = blooms.id) AS rebloom_count
             FROM 
                 reblooms 
                 INNER JOIN blooms ON blooms.id = reblooms.bloom_id
@@ -134,7 +139,7 @@ def get_reblooms_for_user(username: str, *, before: Optional[int] = None, limit:
 
         reblooms = []
         for row in rows:
-            bloom_id, send_username, content, timestamp, rebloomer_name, activity_time = row
+            bloom_id, send_username, content, timestamp, rebloomer_name, activity_time, rebloom_count = row
             reblooms.append(
                 RebloomView(
                     id=bloom_id,
@@ -142,7 +147,8 @@ def get_reblooms_for_user(username: str, *, before: Optional[int] = None, limit:
                     content=content,
                     sent_timestamp=timestamp,
                     rebloomer=rebloomer_name,
-                    activity_timestamp=activity_time
+                    activity_timestamp=activity_time,
+                    rebloom_count=rebloom_count
                 )
             )
     return reblooms
@@ -152,18 +158,23 @@ def get_reblooms_for_user(username: str, *, before: Optional[int] = None, limit:
 def get_bloom(bloom_id: int) -> Optional[Bloom]:
     with db_cursor() as cur:
         cur.execute(
-            "SELECT blooms.id, users.username, content, send_timestamp FROM blooms INNER JOIN users ON users.id = blooms.sender_id WHERE blooms.id = %s",
+            """SELECT 
+                blooms.id, users.username, content, send_timestamp,
+                (SELECT COUNT(*) FROM reblooms WHERE reblooms.bloom_id = blooms.id) AS rebloom_count
+                FROM blooms INNER JOIN users ON users.id = blooms.sender_id WHERE blooms.id = %s""",
             (bloom_id,),
         )
         row = cur.fetchone()
         if row is None:
             return None
-        bloom_id, sender_username, content, timestamp = row
+        bloom_id, sender_username, content, timestamp, rebloom_count = row
         return Bloom(
             id=bloom_id,
             sender=sender_username,
             content=content,
             sent_timestamp=timestamp,
+            activity_timestamp=timestamp,
+            rebloom_count=rebloom_count
         )
 
 
@@ -177,7 +188,8 @@ def get_blooms_with_hashtag(
     with db_cursor() as cur:
         cur.execute(
             f"""SELECT
-              blooms.id, users.username, content, send_timestamp
+              blooms.id, users.username, content, send_timestamp,
+              (SELECT COUNT(*) FROM reblooms WHERE reblooms.bloom_id = blooms.id) AS rebloom_count
             FROM
               blooms INNER JOIN hashtags ON blooms.id = hashtags.bloom_id INNER JOIN users ON blooms.sender_id = users.id
             WHERE
@@ -190,13 +202,15 @@ def get_blooms_with_hashtag(
         rows = cur.fetchall()
         blooms = []
         for row in rows:
-            bloom_id, sender_username, content, timestamp = row
+            bloom_id, sender_username, content, timestamp, rebloom_count = row
             blooms.append(
                 Bloom(
                     id=bloom_id,
                     sender=sender_username,
                     content=content,
                     sent_timestamp=timestamp,
+                    activity_timestamp=timestamp,
+                    rebloom_count=rebloom_count
                 )
             )
     return blooms

--- a/backend/data/blooms.py
+++ b/backend/data/blooms.py
@@ -14,6 +14,15 @@ class Bloom:
     content: str
     sent_timestamp: datetime.datetime
 
+@dataclass
+class RebloomView:
+    id: int
+    sender: str
+    content: str
+    sent_timestamp: datetime.datetime
+    rebloomer: str
+    activity_timestamp: datetime.datetime
+
 def add_bloom(*, sender: User, content: str) -> Bloom:
     hashtags = [word[1:] for word in content.split(" ") if word.startswith("#")]
 
@@ -105,7 +114,7 @@ def get_reblooms_for_user(username: str, *, before: Optional[int] = None, limit:
         cur.execute(
             f"""
             SELECT 
-                blooms.id, users.username, blooms.content, blooms.send_timestamp 
+                blooms.id, users.username AS sender, blooms.content, blooms.send_timestamp, rebloomer.username AS rebloomer, reblooms.rebloom_timestamp AS activity_time
             FROM 
                 reblooms 
                 INNER JOIN blooms ON blooms.id = reblooms.bloom_id
@@ -123,13 +132,15 @@ def get_reblooms_for_user(username: str, *, before: Optional[int] = None, limit:
 
         reblooms = []
         for row in rows:
-            bloom_id, send_username, content, timestamp = row
+            bloom_id, send_username, content, timestamp, rebloomer_name, activity_time = row
             reblooms.append(
-                Bloom(
+                RebloomView(
                     id=bloom_id,
                     sender=send_username,
                     content=content,
                     sent_timestamp=timestamp,
+                    rebloomer=rebloomer_name,
+                    activity_timestamp=activity_time
                 )
             )
     return reblooms

--- a/backend/data/blooms.py
+++ b/backend/data/blooms.py
@@ -36,6 +36,17 @@ def add_bloom(*, sender: User, content: str) -> Bloom:
                 dict(hashtag=hashtag, bloom_id=bloom_id),
             )
 
+def add_rebloom(*, user_id: int, bloom_id: int) -> bool:
+    with db_cursor() as cur:
+        try:
+            cur.execute(
+                "INSERT INTO reblooms (user_id, bloom_id) VALUES (%(user_id)s, %(bloom_id)s) ON CONFLICT (user_id, bloom_id) DO NOTHING", dict(user_id=user_id, bloom_id=bloom_id)
+            )
+            return True
+        except Exception as e:
+            print(f"cannot rebloom bloom: {bloom_id}")
+            return False
+
 
 def get_blooms_for_user(
     username: str, *, before: Optional[int] = None, limit: Optional[int] = None

--- a/backend/data/blooms.py
+++ b/backend/data/blooms.py
@@ -13,6 +13,7 @@ class Bloom:
     sender: User
     content: str
     sent_timestamp: datetime.datetime
+    activity_timestamp: datetime.datetime
 
 @dataclass
 class RebloomView:
@@ -94,6 +95,7 @@ def get_blooms_for_user(
                     sender=sender_username,
                     content=content,
                     sent_timestamp=timestamp,
+                    activity_timestamp=timestamp
                 )
             )
     return blooms

--- a/backend/endpoints.py
+++ b/backend/endpoints.py
@@ -110,12 +110,16 @@ def other_profile(profile_username):
     current_user = get_current_user()
 
     followers = get_inverse_followed_usernames(profile_user)
-    all_blooms = blooms.get_blooms_for_user(profile_username)
-    all_blooms.reverse()
+    own_blooms = blooms.get_blooms_for_user(profile_username)
+    shared_blooms = blooms.get_reblooms_for_user(profile_username)
+    all_blooms = own_blooms + shared_blooms
+    
+    sorted_blooms = list(sorted(all_blooms, key=lambda bloom: bloom.sent_timestamp, reverse=True))
+
     return jsonify(
         {
             "username": profile_username,
-            "recent_blooms": all_blooms[:10],
+            "recent_blooms": sorted_blooms[:10],
             "follows": get_followed_usernames(profile_user),
             "followers": list(followers),
             "is_following": current_user is not None
@@ -177,6 +181,21 @@ def get_bloom(id_str):
         return make_response((f"Bloom not found", 404))
     return jsonify(bloom)
 
+@jwt_required()
+def rebloom(bloom_id):
+    try:
+        id_int = int(bloom_id)
+    except ValueError:
+        return make_response(jsonify({"error": "Invalid bloom id"}), 400)
+
+    current_user = get_current_user()
+
+    success = blooms.add_rebloom(user_id=current_user.id, bloom_id=id_int)
+
+    if success:
+        return make_response(jsonify({"message": "Rebloomed successfully"}), 200)
+    else:
+        return make_response(jsonify({"error": "Failed to rebloom"}), 500)
 
 @jwt_required()
 def home_timeline():
@@ -195,8 +214,11 @@ def home_timeline():
     # Get the current user's own blooms
     own_blooms = blooms.get_blooms_for_user(current_user.username, limit=50)
 
+    # Get the current user's shared blooms
+    shared_blooms = blooms.get_reblooms_for_user(current_user.username, limit=50)
+
     # Combine own blooms with followed blooms
-    all_blooms = followed_blooms + own_blooms
+    all_blooms = followed_blooms + own_blooms + shared_blooms
 
     # Sort by timestamp (newest first)
     sorted_blooms = list(
@@ -205,12 +227,16 @@ def home_timeline():
 
     return jsonify(sorted_blooms)
 
+def user_timeline(profile_username):
+    own_blooms = blooms.get_blooms_for_user(profile_username)
 
-def user_blooms(profile_username):
-    user_blooms = blooms.get_blooms_for_user(profile_username)
-    user_blooms.reverse()
-    return jsonify(user_blooms)
+    shared_blooms = blooms.get_reblooms_for_user(profile_username)
 
+    combined_timeline = own_blooms + shared_blooms
+
+    sorted_timeline = list(sorted(combined_timeline, key=lambda bloom: bloom.sent_timestamp, reverse=True))
+
+    return jsonify(sorted_timeline)
 
 @jwt_required()
 def suggested_follows(limit_str):

--- a/backend/endpoints.py
+++ b/backend/endpoints.py
@@ -193,9 +193,9 @@ def rebloom(bloom_id):
     success = blooms.add_rebloom(user_id=current_user.id, bloom_id=id_int)
 
     if success:
-        return make_response(jsonify({"message": "Rebloomed successfully"}), 200)
+        return make_response(jsonify({"success": True, "message": "Rebloom successfully"}), 200)
     else:
-        return make_response(jsonify({"error": "Failed to rebloom"}), 500)
+        return make_response(jsonify({"success": False, "message": "Failed to rebloom"}), 500)
 
 @jwt_required()
 def home_timeline():

--- a/backend/endpoints.py
+++ b/backend/endpoints.py
@@ -114,7 +114,7 @@ def other_profile(profile_username):
     shared_blooms = blooms.get_reblooms_for_user(profile_username)
     all_blooms = own_blooms + shared_blooms
     
-    sorted_blooms = list(sorted(all_blooms, key=lambda bloom: bloom.sent_timestamp, reverse=True))
+    sorted_blooms = list(sorted(all_blooms, key=lambda bloom: bloom.activity_timestamp, reverse=True))
 
     return jsonify(
         {
@@ -222,7 +222,7 @@ def home_timeline():
 
     # Sort by timestamp (newest first)
     sorted_blooms = list(
-        sorted(all_blooms, key=lambda bloom: bloom.sent_timestamp, reverse=True)
+        sorted(all_blooms, key=lambda bloom: bloom.activity_timestamp, reverse=True)
     )
 
     return jsonify(sorted_blooms)
@@ -234,7 +234,7 @@ def user_timeline(profile_username):
 
     combined_timeline = own_blooms + shared_blooms
 
-    sorted_timeline = list(sorted(combined_timeline, key=lambda bloom: bloom.sent_timestamp, reverse=True))
+    sorted_timeline = list(sorted(combined_timeline, key=lambda bloom: bloom.activity_timestamp, reverse=True))
 
     return jsonify(sorted_timeline)
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,6 +5,7 @@ from data.users import lookup_user
 from endpoints import (
     do_follow,
     get_bloom,
+    rebloom,
     hashtag,
     home_timeline,
     login,
@@ -13,7 +14,7 @@ from endpoints import (
     self_profile,
     send_bloom,
     suggested_follows,
-    user_blooms,
+    user_timeline,
 )
 
 from dotenv import load_dotenv
@@ -58,7 +59,8 @@ def main():
 
     app.add_url_rule("/bloom", methods=["POST"], view_func=send_bloom)
     app.add_url_rule("/bloom/<id_str>", methods=["GET"], view_func=get_bloom)
-    app.add_url_rule("/blooms/<profile_username>", view_func=user_blooms)
+    app.add_url_rule("/blooms/<int:bloom_id>/rebloom", methods=["POST"], view_func=rebloom)
+    app.add_url_rule("/blooms/<profile_username>", view_func=user_timeline)
     app.add_url_rule("/hashtag/<hashtag>", view_func=hashtag)
 
     app.run(host="0.0.0.0", port="3000", debug=True)

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -26,3 +26,11 @@ CREATE TABLE hashtags (
     bloom_id BIGINT NOT NULL REFERENCES blooms(id),
     UNIQUE(hashtag, bloom_id)
 );
+
+CREATE TABLE reblooms (
+    id SERIAL PRIMARY KEY,
+    user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    bloom_id BIGINT NOT NULL REFERENCES blooms(id) ON DELETE CASCADE,
+    rebloom_timestamp TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(user_id, bloom_id)
+);

--- a/front-end/components/bloom.mjs
+++ b/front-end/components/bloom.mjs
@@ -26,6 +26,7 @@ const createBloom = (template, bloom) => {
   const rebloomBtn = bloomFrag.querySelector("[data-action='rebloom']");
   const rebloomHeader = bloomFrag.querySelector("[data-rebloom-header]");
   const rebloomBy = bloomFrag.querySelector("[data-rebloom-by]");
+  const rebloomCountLabel = bloomFrag.querySelector("[data-rebloom-count]");
 
   bloomArticle.setAttribute("data-bloom-id", bloom.id);
 
@@ -40,6 +41,15 @@ const createBloom = (template, bloom) => {
       rebloomBy.setAttribute("href", `/profile/${bloom.rebloomer}`);
       rebloomBy.textContent = bloom.rebloomer;
 
+    }
+  }
+
+  if (rebloomCountLabel) {
+    if (bloom.rebloom_count > 0) {
+      rebloomCountLabel.textContent = `(${bloom.rebloom_count})`;
+      rebloomCountLabel.classList.remove("is-hidden");
+    } else {
+      rebloomCountLabel.classList.add("is-hidden");
     }
   }
 

--- a/front-end/components/bloom.mjs
+++ b/front-end/components/bloom.mjs
@@ -1,4 +1,3 @@
-import { stat } from "node:fs";
 import { apiService } from "../index.mjs";
 import { state } from "../lib/state.mjs";
 
@@ -24,12 +23,24 @@ const createBloom = (template, bloom) => {
   const bloomTime = bloomFrag.querySelector("[data-time]");
   const bloomTimeLink = bloomFrag.querySelector("a:has(> [data-time])");
   const bloomContent = bloomFrag.querySelector("[data-content]");
-  const rebloomBtn = bloomFrag.querySelector("[data-action='rebloom']")
+  const rebloomBtn = bloomFrag.querySelector("[data-action='rebloom']");
+  const rebloomHeader = bloomFrag.querySelector("[data-rebloom-header]");
+  const rebloomBy = bloomFrag.querySelector("[data-rebloom-by]");
 
   bloomArticle.setAttribute("data-bloom-id", bloom.id);
 
-  if (state.currentUser && bloom.sender !== state.currentUser) {
+  bloomArticle.removeAttribute("data-is-rebloom");
+  if (rebloomHeader) rebloomHeader.classList.add("is-hidden");
+
+  if (bloom.rebloomer) {
     bloomArticle.setAttribute("data-is-rebloom", "true");
+
+    if (rebloomHeader && rebloomBy) {
+      rebloomHeader.classList.remove("is-hidden");
+      rebloomBy.setAttribute("href", `/profile/${bloom.rebloomer}`);
+      rebloomBy.textContent = bloom.rebloomer;
+
+    }
   }
 
   bloomUsername.setAttribute("href", `/profile/${bloom.sender}`);
@@ -45,7 +56,9 @@ const createBloom = (template, bloom) => {
     rebloomBtn.addEventListener("click", async (e) => {
       e.preventDefault();
       rebloomBtn.disabled = true;
-      await apiService.postRebloom(bloom.id);
+      console.log(bloom)
+      const response = await apiService.postRebloom(bloom.id);
+      console.log("API service responded with", response);
       rebloomBtn.disabled = false;
     })
   }

--- a/front-end/components/bloom.mjs
+++ b/front-end/components/bloom.mjs
@@ -1,4 +1,6 @@
+import { stat } from "node:fs";
 import { apiService } from "../index.mjs";
+import { state } from "../lib/state.mjs";
 
 /**
  * Create a bloom component
@@ -25,6 +27,11 @@ const createBloom = (template, bloom) => {
   const rebloomBtn = bloomFrag.querySelector("[data-action='rebloom']")
 
   bloomArticle.setAttribute("data-bloom-id", bloom.id);
+
+  if (state.currentUser && bloom.sender !== state.currentUser) {
+    bloomArticle.setAttribute("data-is-rebloom", "true");
+  }
+
   bloomUsername.setAttribute("href", `/profile/${bloom.sender}`);
   bloomUsername.textContent = bloom.sender;
   bloomTime.textContent = _formatTimestamp(bloom.sent_timestamp);

--- a/front-end/components/bloom.mjs
+++ b/front-end/components/bloom.mjs
@@ -1,3 +1,5 @@
+import { apiService } from "../index.mjs";
+
 /**
  * Create a bloom component
  * @param {string} template - The ID of the template to clone
@@ -20,6 +22,7 @@ const createBloom = (template, bloom) => {
   const bloomTime = bloomFrag.querySelector("[data-time]");
   const bloomTimeLink = bloomFrag.querySelector("a:has(> [data-time])");
   const bloomContent = bloomFrag.querySelector("[data-content]");
+  const rebloomBtn = bloomFrag.querySelector("[data-action='rebloom']")
 
   bloomArticle.setAttribute("data-bloom-id", bloom.id);
   bloomUsername.setAttribute("href", `/profile/${bloom.sender}`);
@@ -30,6 +33,15 @@ const createBloom = (template, bloom) => {
     ...bloomParser.parseFromString(_formatHashtags(bloom.content), "text/html")
       .body.childNodes
   );
+
+  if (rebloomBtn) {
+    rebloomBtn.addEventListener("click", async (e) => {
+      e.preventDefault();
+      rebloomBtn.disabled = true;
+      await apiService.postRebloom(bloom.id);
+      rebloomBtn.disabled = false;
+    })
+  }
 
   return bloomFrag;
 };

--- a/front-end/index.css
+++ b/front-end/index.css
@@ -194,6 +194,11 @@ dialog {
   grid-area: char-count;
 }
 
+[data-is-rebloom="true"] {
+  border-left: 4px solid #7149c6;
+  background-color: #f9f6ff;
+}
+
 /* LOGIN */
 .login__container {
   margin: 1em 0 auto auto;

--- a/front-end/index.css
+++ b/front-end/index.css
@@ -194,9 +194,32 @@ dialog {
   grid-area: char-count;
 }
 
-[data-is-rebloom="true"] {
-  border-left: 4px solid #7149c6;
+/* REBLOOM */
+
+.bloom.box[data-is-rebloom="true"] {
+  border-left: 4px solid #7149c6 !important;
   background-color: #f9f6ff;
+  box-shadow: inset 0 0 8px rgba(113, 73, 198, 0.02);
+}
+
+.bloom__rebloom-header {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #657786;
+  margin-bottom: 8px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.bloom__rebloom-author {
+  font-weight: 700;
+  color: #7149c6;
+  text-decoration: none;
+}
+
+.bloom__rebloom-author:hover {
+  text-decoration: underline;
 }
 
 /* LOGIN */
@@ -269,6 +292,6 @@ dialog {
 }
 
 /* We always want attribute hidden to sync with display:none, no matter what */
-[hidden] {
+.is-hidden, [hidden] {
   display: none !important;
 }

--- a/front-end/index.html
+++ b/front-end/index.html
@@ -234,6 +234,9 @@
     <!-- Bloom Template -->
     <template id="bloom-template">
       <article class="bloom box" data-bloom data-bloom-id="">
+        <div class="bloom__rebloom-header is-hidden" data-rebloom-header>
+          🔄 rebloomed by <a href="#" class="bloom__rebloom-author" data-rebloom-by> User</a>
+        </div>
         <div class="bloom__header flex">
           <a href="#" class="bloom__username" data-username>Username</a>
           <a href="#" class="bloom__time"><time class="bloom__time" data-time>2m</time></a>

--- a/front-end/index.html
+++ b/front-end/index.html
@@ -244,7 +244,7 @@
         <div class="bloom__content" data-content></div>
         <div class="bloom__actions">
           <button type="button" data-action="rebloom" class="bloom__rebloom-btn" aria-label="Rebloom this post">
-            🔄 Rebloom
+            🔄 Rebloom <span data-rebloom-count class="is-hidden"></span>
           </button>
         </div>
       </article>

--- a/front-end/index.html
+++ b/front-end/index.html
@@ -239,6 +239,11 @@
           <a href="#" class="bloom__time"><time class="bloom__time" data-time>2m</time></a>
         </div>
         <div class="bloom__content" data-content></div>
+        <div class="bloom__actions">
+          <button type="button" data-action="rebloom" class="bloom__rebloom-btn" aria-label="Rebloom this post">
+            🔄 Rebloom
+          </button>
+        </div>
       </article>
     </template>
 

--- a/front-end/lib/api.mjs
+++ b/front-end/lib/api.mjs
@@ -217,11 +217,16 @@ async function postRebloom(bloomId) {
     const data = await _apiRequest(`/blooms/${bloomId}/rebloom`, {
       method: "POST"
     });
+    console.log("Network response received:", data)
     if (data.success) {
-      await Promise.all([
-        getBlooms(),
-        getProfile(state.currentUser)
-      ]);
+      const reFetchingForHome = await getBlooms();
+      console.log("Refetching for home:", reFetchingForHome)
+      if (state.currentUser) {
+        const updateUserProfile = await getProfile(state.currentUser);
+        const updateUserBlooms = await getBlooms(state.currentUser);
+        console.log("update user profile", updateUserProfile);
+        console.log("update user blooms", updateUserBlooms);
+      }
     }
     return data;
   } catch (error) {
@@ -309,6 +314,7 @@ const apiService = {
   getBlooms,
   postBloom,
   getBloomsByHashtag,
+  postRebloom,
 
   // User methods
   getProfile,

--- a/front-end/lib/api.mjs
+++ b/front-end/lib/api.mjs
@@ -212,6 +212,23 @@ async function postBloom(content) {
   }
 }
 
+async function postRebloom(bloomId) {
+  try {
+    const data = await _apiRequest(`/blooms/${bloomId}/rebloom`, {
+      method: "POST"
+    });
+    if (data.success) {
+      await Promise.all([
+        getBlooms(),
+        getProfile(state.currentUser)
+      ]);
+    }
+    return data;
+  } catch (error) {
+    return {success: false}
+  }
+}
+
 // ======= USER methods
 async function getProfile(username) {
   const endpoint = username ? `/profile/${username}` : "/profile";


### PR DESCRIPTION
<!--

You must title your PR like this:

Region | Cohort | FirstName LastName | Sprint | Assignment Title

For example,

London | 25-ITP-May | Carol Owen | Sprint 1 | Alarm Clock

Fill in the template below - remove any sections that don't apply.

Complete the self checklist - replace each empty box in the checklist [ ] with a [x].

Add the label "Needs Review" and you will get review.

Respond to volunteer reviews until the volunteer marks it as "Complete".

Please note: if the PR template is not filled as described above, an automatic GitHub bot will give feedback in the "Conversation" tab of the pull request and not allow the "Needs Review" label to be added until it's fixed.

-->

## Learners, PR Template

Self checklist

- [x] I have titled my PR with Region | Cohort | FirstName LastName | Sprint | Assignment Title
- [x] My changes meet the requirements of the task
- [x] I have tested my changes
- [x] My changes follow the [style guide](https://curriculum.codeyourfuture.io/guides/reviewing/style-guide/)

## Changelist

Backend Changes
Created a separate `RebloomView` dataclass in `data/blooms.py` to handle shared posts cleanly, keeping the original `Bloom` class lightweight.
Refactored feed sorting in `endpoints.py` to use a new `activity_timestamp`. This ensures `home_timeline`, `user_timeline`, and `other_profile` sort sequentially by interaction time (creation vs. rebloom time).
Integrated a SQL subquery to dynamically calculate the live `rebloom_count` for each post.

Frontend Changes
Updated `createBloom in `bloom.mjs` to conditionally display the "Rebloomed by [User]" header and toggle the interactive counter badge.
Expanded the HTML template and styles (`index.html` / `index.css`) with a dedicated `data-is-rebloom="true"` theme to give shared posts a distinctive look.